### PR TITLE
fix: use winit scale factor for native file drop position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1098,6 +1098,12 @@ if(BUILD_TESTING)
         avif_enable_common_options(awj_cli_config_entry)
         target_link_libraries(awj_cli_config_entry PRIVATE awj_base)
 
+        add_executable(awj_shell_context_menu_tests
+            tests/shell_context_menu_tests.cpp)
+        avif_enable_common_options(awj_shell_context_menu_tests)
+        target_include_directories(awj_shell_context_menu_tests PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/ui")
+
         add_executable(awj_cli_native_avif_aom_tests tests/cli_native_avif_aom_tests.cpp)
         avif_enable_common_options(awj_cli_native_avif_aom_tests)
         target_link_libraries(awj_cli_native_avif_aom_tests PRIVATE awj_native_backend)
@@ -1132,6 +1138,7 @@ if(BUILD_TESTING)
             awj_native_pipeline_tests
             awj_pipeline_security_tests
             awj_cli_config_entry
+            awj_shell_context_menu_tests
             awj_cli_native_avif_aom_tests)
     endif()
     if(AWJ_JPEGLI_AVAILABLE)
@@ -1161,6 +1168,7 @@ if(BUILD_TESTING)
     add_test(NAME bmp_codec_core COMMAND awj_bmp_codec_tests)
     if(WIN32)
         add_test(NAME jxr_codec_core COMMAND awj_jxr_codec_tests)
+        add_test(NAME shell_context_menu_model COMMAND awj_shell_context_menu_tests)
     endif()
     if(AWJ_JPEGLI_AVAILABLE)
         add_test(NAME jpegli_codec_core COMMAND awj_jpegli_codec_tests)
@@ -1285,6 +1293,7 @@ endif()
 if(WIN32)
     target_link_libraries(AWJ PRIVATE
         dwmapi
+        advapi32
         gdi32
         ole32
         shell32

--- a/cmake/embed_changelog.cmake
+++ b/cmake/embed_changelog.cmake
@@ -21,7 +21,57 @@ get_filename_component(output_dir "${OUTPUT}" DIRECTORY)
 file(MAKE_DIRECTORY "${output_dir}")
 file(WRITE "${OUTPUT}" "#pragma once\n"
     "#include <string_view>\n\n"
-    "namespace awj::embedded_changelog {\n"
-    "inline constexpr std::string_view zh = R\"${delimiter_zh}(${changelog_zh})${delimiter_zh}\";\n"
-    "inline constexpr std::string_view en = R\"${delimiter_en}(${changelog_en})${delimiter_en}\";\n"
-    "}  // namespace awj::embedded_changelog\n")
+    "namespace awj::embedded_changelog {\n")
+
+# MSVC rejects a single string literal larger than roughly 16 KiB. Keep each
+# raw-string fragment below that limit while only splitting at UTF-8 newlines.
+function(append_chunked_string_view output text delimiter)
+    string(LENGTH "${text}" text_length)
+    set(offset 0)
+    file(APPEND "${output}" "    ")
+    if(text_length EQUAL 0)
+        file(APPEND "${output}" "R\"${delimiter}()${delimiter}\";\n")
+        return()
+    endif()
+    set(first_fragment TRUE)
+    while(offset LESS text_length)
+        math(EXPR remaining "${text_length} - ${offset}")
+        set(fragment_length 4096)
+        if(remaining LESS fragment_length)
+            set(fragment_length ${remaining})
+        endif()
+
+        # Changelog lines are short, but find a newline defensively so a
+        # multibyte UTF-8 code point is never split between literals.
+        math(EXPR fragment_end "${offset} + ${fragment_length}")
+        if(fragment_end LESS text_length)
+            while(fragment_end GREATER offset)
+                math(EXPR last_index "${fragment_end} - 1")
+                string(SUBSTRING "${text}" ${last_index} 1 last_character)
+                if(last_character STREQUAL "\n")
+                    break()
+                endif()
+                math(EXPR fragment_end "${fragment_end} - 1")
+            endwhile()
+            if(fragment_end EQUAL offset)
+                set(fragment_end "${offset} + ${fragment_length}")
+                math(EXPR fragment_end "${offset} + ${fragment_length}")
+            endif()
+        endif()
+        math(EXPR actual_length "${fragment_end} - ${offset}")
+        string(SUBSTRING "${text}" ${offset} ${actual_length} fragment)
+        if(NOT first_fragment)
+            file(APPEND "${output}" "\n    ")
+        endif()
+        file(APPEND "${output}" "R\"${delimiter}(${fragment})${delimiter}\"")
+        set(first_fragment FALSE)
+        set(offset ${fragment_end})
+    endwhile()
+    file(APPEND "${output}" ";\n")
+endfunction()
+
+file(APPEND "${OUTPUT}" "inline constexpr std::string_view zh =\n")
+append_chunked_string_view("${OUTPUT}" "${changelog_zh}" "${delimiter_zh}")
+file(APPEND "${OUTPUT}" "inline constexpr std::string_view en =\n")
+append_chunked_string_view("${OUTPUT}" "${changelog_en}" "${delimiter_en}")
+file(APPEND "${OUTPUT}" "}  // namespace awj::embedded_changelog\n")

--- a/cmake/patch_slint_static_import.cmake
+++ b/cmake/patch_slint_static_import.cmake
@@ -22,14 +22,116 @@ endif()
 file(TOUCH "${SOURCE_DIR}/api/cpp/build.rs")
 
 # Slint 1.17 exposes DropArea/DataTransfer, while its Winit backend currently
-# leaves Winit's native DroppedFile events untranslated.  AWJ needs the public
+# leaves Winit's native DroppedFile events untranslated. AWJ needs the public
 # DropArea path on both desktop platforms, not a Win32 WM_DROPFILES shim.
 set(WINIT_EVENT_LOOP "${SOURCE_DIR}/internal/backends/winit/event_loop.rs")
 if(NOT EXISTS "${WINIT_EVENT_LOOP}")
     message(FATAL_ERROR "Slint Winit event loop source not found.")
 endif()
+
+# The native-drop position helper uses POINT on Windows. Keep the dependency
+# explicit instead of relying on feature unification from another Slint crate.
+set(WINIT_CARGO_TOML "${SOURCE_DIR}/internal/backends/winit/Cargo.toml")
+if(NOT EXISTS "${WINIT_CARGO_TOML}")
+    message(FATAL_ERROR "Slint Winit Cargo.toml not found.")
+endif()
+file(READ "${WINIT_CARGO_TOML}" WINIT_CARGO_CONTENT)
+if(NOT WINIT_CARGO_CONTENT MATCHES "Win32_Foundation")
+    string(REPLACE
+        "windows = { workspace = true, features = [\"Win32_UI_WindowsAndMessaging\", \"Win32_UI_HiDpi\", \"Win32_Graphics_Gdi\", \"Win32_Graphics_Dwm\"] }"
+        "windows = { workspace = true, features = [\"Win32_Foundation\", \"Win32_UI_WindowsAndMessaging\", \"Win32_UI_HiDpi\", \"Win32_Graphics_Gdi\", \"Win32_Graphics_Dwm\"] }"
+        WINIT_CARGO_PATCHED "${WINIT_CARGO_CONTENT}")
+    if(WINIT_CARGO_PATCHED STREQUAL WINIT_CARGO_CONTENT)
+        message(FATAL_ERROR "Could not add the Slint Winit Windows foundation feature.")
+    endif()
+    file(WRITE "${WINIT_CARGO_TOML}" "${WINIT_CARGO_PATCHED}")
+endif()
+
 file(READ "${WINIT_EVENT_LOOP}" WINIT_CONTENT)
-if(NOT WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V2")
+# V3 was briefly generated before native file drops retained their exact
+# position. Upgrade those already-patched build trees before deciding whether a
+# full patch is needed.
+if(WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V3" AND
+   NOT WINIT_CONTENT MATCHES "fallback_position = self.cursor_pos")
+    set(WINIT_V3_OLD_DROP_EVENT
+        "            WindowEvent::DroppedFile(path) => {\n                let fallback_position = self.cursor_pos;\n                let position = window\n                    .winit_window()\n                    .map(|winit_window| {\n                        native_file_drop_position(\n                            &winit_window,\n                            winit_window.scale_factor(),\n                            fallback_position,\n                        )\n                    })\n                    .unwrap_or(fallback_position);\n                self.cursor_pos = position;\n                self.pending_native_file_drops.push((window_id, path, position));\n            }")
+    set(WINIT_V3_NEW_DROP_EVENT
+        "            WindowEvent::DroppedFile(path) => {\n                let fallback_position = self.cursor_pos;\n                let position = window\n                    .winit_window()\n                    .map(|winit_window| {\n                        native_file_drop_position(\n                            &winit_window,\n                            runtime_window.scale_factor() as f64,\n                            fallback_position,\n                        )\n                    })\n                    .unwrap_or(fallback_position);\n                self.cursor_pos = position;\n                self.pending_native_file_drops.push((window_id, path, position));\n            }")
+    string(REPLACE "${WINIT_V3_OLD_DROP_EVENT}" "${WINIT_V3_NEW_DROP_EVENT}"
+        WINIT_PATCHED "${WINIT_CONTENT}")
+    string(REPLACE
+        "let logical_position = physical_position.to_logical(scale_factor);"
+        "let logical_position = physical_position.to_logical::<corelib::Coord>(scale_factor);"
+        WINIT_PATCHED "${WINIT_PATCHED}")
+    string(REPLACE
+        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_native_file_drops();\n        self.flush_pending_mouse_move();"
+        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_mouse_move();\n        self.flush_pending_native_file_drops();"
+        WINIT_PATCHED "${WINIT_PATCHED}")
+    if(WINIT_PATCHED STREQUAL WINIT_CONTENT)
+        message(FATAL_ERROR "Could not upgrade the existing Slint native-drop patch.")
+    endif()
+    file(WRITE "${WINIT_EVENT_LOOP}" "${WINIT_PATCHED}")
+    set(WINIT_CONTENT "${WINIT_PATCHED}")
+endif()
+if(WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V3")
+    # Idempotent DPI migration: if the old scale source is present, replace it.
+    # If absent, the tree is already migrated and the replace is a no-op.
+    string(REPLACE
+        "                            runtime_window.scale_factor() as f64,"
+        "                            winit_window.scale_factor(),"
+        WINIT_PATCHED "${WINIT_CONTENT}")
+    if(NOT WINIT_PATCHED STREQUAL WINIT_CONTENT)
+        file(WRITE "${WINIT_EVENT_LOOP}" "${WINIT_PATCHED}")
+        set(WINIT_CONTENT "${WINIT_PATCHED}")
+    endif()
+endif()
+if(NOT WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V3")
+    set(WINIT_NATIVE_DROP_POSITION "\nfn native_file_drop_position(\n    window: &winit::window::Window,\n    scale_factor: f64,\n    fallback: LogicalPoint,\n) -> LogicalPoint {\n    #[cfg(target_os = \"windows\")]\n    {\n        use windows::Win32::Foundation::POINT;\n        use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;\n\n        let mut screen_position = POINT::default();\n        if unsafe { GetCursorPos(&mut screen_position) }.is_ok() {\n            if let Ok(client_origin) = window.inner_position() {\n                let physical_position = winit::dpi::PhysicalPosition::new(\n                    screen_position.x - client_origin.x,\n                    screen_position.y - client_origin.y,\n                );\n                let logical_position = physical_position.to_logical::<corelib::Coord>(scale_factor);\n                return euclid::point2(logical_position.x, logical_position.y);\n            }\n        }\n    }\n    #[cfg(not(target_os = \"windows\"))]\n    let _ = (window, scale_factor);\n    fallback\n}\n")
+    set(WINIT_DROPPED_FILE_EVENT "            WindowEvent::DroppedFile(path) => {\n                let fallback_position = self.cursor_pos;\n                let position = window\n                    .winit_window()\n                    .map(|winit_window| {\n                        native_file_drop_position(\n                            &winit_window,\n                            winit_window.scale_factor(),\n                            fallback_position,\n                        )\n                    })\n                    .unwrap_or(fallback_position);\n                self.cursor_pos = position;\n                self.pending_native_file_drops.push((window_id, path, position));\n            }\n")
+
+    # Support reconfiguration of an existing build tree that contains the
+    # previous V2 patch, as well as pristine Slint sources in a fresh build.
+    if(WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V2")
+        set(WINIT_PATCHED "${WINIT_CONTENT}")
+        string(REPLACE "AWJ_NATIVE_FILE_DND_V2" "AWJ_NATIVE_FILE_DND_V3"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf)>,"
+            "pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf, LogicalPoint)>,"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "use winit::keyboard::Key;\n"
+            "use winit::keyboard::Key;${WINIT_NATIVE_DROP_POSITION}\n"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "        for (window_id, path) in pending {"
+            "        for (window_id, path, position) in pending {"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "        let mut grouped: Vec<(winit::window::WindowId, String)> = Vec::new();"
+            "        let mut grouped: Vec<(winit::window::WindowId, LogicalPoint, String)> = Vec::new();"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "if let Some((_, paths)) = grouped.iter_mut().find(|(id, _)| *id == window_id)"
+            "if let Some((_, _, paths)) = grouped.iter_mut().find(|(id, _, _)| *id == window_id)"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "                grouped.push((window_id, path.to_string_lossy().into_owned()));"
+            "                grouped.push((window_id, position, path.to_string_lossy().into_owned()));"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "        for (window_id, paths) in grouped {"
+            "        for (window_id, position, paths) in grouped {"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "event.position = corelib::api::LogicalPosition::new(self.cursor_pos.x, self.cursor_pos.y);"
+            "event.position = corelib::api::LogicalPosition::new(position.x, position.y);"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "            WindowEvent::DroppedFile(path) => {\n                self.pending_native_file_drops.push((window_id, path));\n            }\n"
+            "${WINIT_DROPPED_FILE_EVENT}"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+    else()
     string(REPLACE
         "use corelib::SharedString;\nuse corelib::graphics::euclid;\nuse corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};\nuse corelib::items::{ColorScheme, PointerEventButton};"
         "use corelib::SharedString;\nuse corelib::DataTransfer;\nuse corelib::graphics::euclid;\nuse corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};\nuse corelib::items::{AllowedDragActions, ColorScheme, DragAction, DropEvent, PointerEventButton};"
@@ -39,25 +141,36 @@ if(NOT WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V2")
     endif()
     string(REPLACE
         "    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,"
-        "    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,\n\n    // AWJ_NATIVE_FILE_DND_V2: batch paths reported in one native Winit turn.\n    pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf)>,"
+        "    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,\n\n    // AWJ_NATIVE_FILE_DND_V3: batch paths and the native drop position.\n    pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf, LogicalPoint)>,"
         WINIT_PATCHED "${WINIT_PATCHED}")
     string(REPLACE
         "            pending_mouse_move: Default::default(),"
         "            pending_mouse_move: Default::default(),\n            pending_native_file_drops: Default::default(),"
         WINIT_PATCHED "${WINIT_PATCHED}")
-    set(WINIT_FLUSH_NATIVE "\n    fn flush_pending_native_file_drops(&mut self) {\n        let pending = std::mem::take(&mut self.pending_native_file_drops);\n        let mut grouped: Vec<(winit::window::WindowId, String)> = Vec::new();\n        for (window_id, path) in pending {\n            if let Some((_, paths)) = grouped.iter_mut().find(|(id, _)| *id == window_id) {\n                if !paths.is_empty() { paths.push('\\n'); }\n                paths.push_str(&path.to_string_lossy());\n            } else {\n                grouped.push((window_id, path.to_string_lossy().into_owned()));\n            }\n        }\n        for (window_id, paths) in grouped {\n            let Some(window) = self.shared_backend_data.window_by_id(window_id) else { continue; };\n            let runtime_window = WindowInner::from_pub(window.window());\n            let mut data = DataTransfer::default();\n            data.set_plain_text(paths.into());\n            let mut event = DropEvent::default();\n            event.data = data;\n            event.position = corelib::api::LogicalPosition::new(self.cursor_pos.x, self.cursor_pos.y);\n            event.proposed_action = DragAction::Copy;\n            let allowed = AllowedDragActions { copy: true, move_: false, link: false };\n            runtime_window.process_mouse_input(MouseEvent::DragMove { event: event.clone(), allowed });\n            runtime_window.process_mouse_input(MouseEvent::Drop { event, allowed });\n        }\n    }\n")
+    string(REPLACE
+        "use winit::keyboard::Key;\n"
+        "use winit::keyboard::Key;${WINIT_NATIVE_DROP_POSITION}\n"
+        WINIT_PATCHED "${WINIT_PATCHED}")
+    set(WINIT_FLUSH_NATIVE "\n    fn flush_pending_native_file_drops(&mut self) {\n        let pending = std::mem::take(&mut self.pending_native_file_drops);\n        let mut grouped: Vec<(winit::window::WindowId, LogicalPoint, String)> = Vec::new();\n        for (window_id, path, position) in pending {\n            if let Some((_, _, paths)) = grouped.iter_mut().find(|(id, _, _)| *id == window_id) {\n                if !paths.is_empty() { paths.push('\\n'); }\n                paths.push_str(&path.to_string_lossy());\n            } else {\n                grouped.push((window_id, position, path.to_string_lossy().into_owned()));\n            }\n        }\n        for (window_id, position, paths) in grouped {\n            let Some(window) = self.shared_backend_data.window_by_id(window_id) else { continue; };\n            let runtime_window = WindowInner::from_pub(window.window());\n            let mut data = DataTransfer::default();\n            data.set_plain_text(paths.into());\n            let mut event = DropEvent::default();\n            event.data = data;\n            event.position = corelib::api::LogicalPosition::new(position.x, position.y);\n            event.proposed_action = DragAction::Copy;\n            let allowed = AllowedDragActions { copy: true, move_: false, link: false };\n            runtime_window.process_mouse_input(MouseEvent::DragMove { event: event.clone(), allowed });\n            runtime_window.process_mouse_input(MouseEvent::Drop { event, allowed });\n        }\n    }\n")
     string(REPLACE
         "    }\n}\n\nimpl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {"
         "    }${WINIT_FLUSH_NATIVE}}\n\nimpl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {"
         WINIT_PATCHED "${WINIT_PATCHED}")
     string(REPLACE
         "            WindowEvent::CursorMoved { position, .. } => {"
-        "            WindowEvent::DroppedFile(path) => {\n                self.pending_native_file_drops.push((window_id, path));\n            }\n            WindowEvent::CursorMoved { position, .. } => {"
+        "${WINIT_DROPPED_FILE_EVENT}            WindowEvent::CursorMoved { position, .. } => {"
         WINIT_PATCHED "${WINIT_PATCHED}")
     string(REPLACE
         "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_mouse_move();"
-        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_native_file_drops();\n        self.flush_pending_mouse_move();"
+        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_mouse_move();\n        self.flush_pending_native_file_drops();"
         WINIT_PATCHED "${WINIT_PATCHED}")
+    endif()
+
+    if(NOT WINIT_PATCHED MATCHES "AWJ_NATIVE_FILE_DND_V3" OR
+       NOT WINIT_PATCHED MATCHES "native_file_drop_position" OR
+       NOT WINIT_PATCHED MATCHES "pending_native_file_drops.push\\(\\(window_id, path, position\\)\\)")
+        message(FATAL_ERROR "Could not upgrade Slint Winit native-drop event handling.")
+    endif()
     if(WINIT_PATCHED STREQUAL WINIT_CONTENT)
         message(FATAL_ERROR "Could not add Slint Winit native-drop event handling.")
     endif()

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -30,6 +30,7 @@ int run_cli(int argc, char* argv[]);
 int run_studio_ui();
 #endif
 int run_shell_convert_window(int argc, wchar_t* argv[]);
+int run_shell_context_menu_helper(int argc, wchar_t* argv[]);
 
 #ifdef _WIN32
 namespace {
@@ -274,6 +275,13 @@ int wmain(int argc, wchar_t* argv[]) {
     release_explorer_console_if_lonely();
     return run_guarded("update-health-check", [argv] {
       return run_studio_ui(argv[2], argv[3]);
+    });
+  }
+  if (argc == 2 &&
+      (std::wcscmp(argv[1], L"--shell-context-menu-helper") == 0 ||
+       std::wcscmp(argv[1], L"--shell-context-menu-remove-helper") == 0)) {
+    return run_guarded("shell-context-menu-helper", [argc, argv] {
+      return run_shell_context_menu_helper(argc, argv);
     });
   }
   if (awj::update::launch_update_recovery_if_needed()) {

--- a/src/core/raw_image_io.ixx
+++ b/src/core/raw_image_io.ixx
@@ -5,6 +5,7 @@ module;
 #endif
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -264,7 +265,8 @@ std::expected<void, std::string> write_wgc_scrgb_half_stream_file(
         return std::unexpected{"WGC stdin 数据短于声明的 16-bit RGBA 帧。"};
       }
       if (auto written = raw_image_detail::write_all(
-              output.get(), buffer.data(), static_cast<std::uint64_t>(received), path);
+              output.get(), buffer.data(), static_cast<std::uint64_t>(received),
+              path);
           !written) {
         return std::unexpected{written.error()};
       }

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -51,6 +51,7 @@
 
 #include "awj_studio.h"
 #include "changelog_history.h"
+#include "shell_context_menu.h"
 
 import awj.avif_aom_codec;
 import awj.avif_registry;
@@ -3116,21 +3117,11 @@ std::wstring command_line_from_args(std::span<const std::wstring> args) {
   return command;
 }
 
-struct ShellConvertCommand {
-  std::wstring_view key{};
-  std::wstring_view label{};
-  std::wstring_view format{};
-  bool append_png_suffix{};
-};
-
-constexpr std::wstring_view shell_image_menu_key =
-    L"Software\\Classes\\SystemFileAssociations\\image\\shell\\AWJImage";
-constexpr std::wstring_view shell_icofile_menu_key =
-    L"Software\\Classes\\icofile\\shell\\AWJImage";
-constexpr std::wstring_view shell_directory_menu_key =
-    L"Software\\Classes\\Directory\\shell\\AWJImage";
-constexpr std::wstring_view shell_legacy_subcommands_key =
-    L"Software\\Classes\\AWJImage.ContextMenu";
+using ShellConvertCommand = awj::ui::ShellContextMenuCommand;
+constexpr auto shell_image_menu_key = awj::ui::shell_image_menu_key;
+constexpr auto shell_icofile_menu_key = awj::ui::shell_icofile_menu_key;
+constexpr auto shell_directory_menu_key = awj::ui::shell_directory_menu_key;
+constexpr auto shell_legacy_subcommands_key = awj::ui::shell_legacy_subcommands_key;
 
 constexpr std::wstring_view shell_supported_image_extensions[] = {
     L".jpg",    L".jpeg", L".jpe", L".jfif", L".png",  L".webp",
@@ -3141,33 +3132,107 @@ constexpr std::wstring_view shell_supported_image_extensions[] = {
     L".mrw",    L".raw",  L".heic", L".heif", L".jxr",  L".wdp",
     L".hdp"};
 
-constexpr ShellConvertCommand shell_convert_commands[] = {
-    {.key = L"png", .label = L"转换为 PNG", .format = L"png"},
-    {.key = L"webp", .label = L"转换为 WebP", .format = L"webp"},
-    {.key = L"avif", .label = L"转换为 AVIF", .format = L"avif"},
-    {.key = L"avif-png", .label = L"转换为 AVIF.png", .format = L"avif", .append_png_suffix = true},
-    {.key = L"jxl", .label = L"转换为 JXL", .format = L"jxl"},
-    {.key = L"jpgli", .label = L"转换为 JPGLI", .format = L"jpgli"},
-};
+constexpr auto shell_convert_commands = awj::ui::shell_context_menu_commands;
 
 std::expected<void, std::string> set_registry_string(HKEY root,
                                                      std::wstring_view subkey,
                                                      std::wstring_view value_name,
                                                      std::wstring_view value) {
+  if (value.size() >
+      (std::numeric_limits<DWORD>::max() / sizeof(wchar_t)) - 1u) {
+    return std::unexpected{"写入右键菜单注册表值失败，字符串过长。"};
+  }
+  const std::wstring subkey_storage{subkey};
+  const std::wstring value_name_storage{value_name};
+  const std::wstring value_storage{value};
   HKEY raw_key = nullptr;
-  const auto created = RegCreateKeyExW(root, std::wstring{subkey}.c_str(), 0, nullptr,
+  const auto created = RegCreateKeyExW(root, subkey_storage.c_str(), 0, nullptr,
                                        REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr,
                                        &raw_key, nullptr);
   if (created != ERROR_SUCCESS) {
     return std::unexpected{std::format("写入右键菜单注册表失败，错误码 {}。", created)};
   }
-  const auto bytes = static_cast<DWORD>((value.size() + 1) * sizeof(wchar_t));
-  const auto set = RegSetValueExW(raw_key, value_name.empty() ? nullptr : std::wstring{value_name}.c_str(),
-                                  0, REG_SZ,
-                                  reinterpret_cast<const BYTE*>(value.data()), bytes);
+  const auto bytes = static_cast<DWORD>((value_storage.size() + 1) * sizeof(wchar_t));
+  const auto set = RegSetValueExW(
+      raw_key, value_name_storage.empty() ? nullptr : value_name_storage.c_str(),
+      0, REG_SZ, reinterpret_cast<const BYTE*>(value_storage.c_str()), bytes);
   RegCloseKey(raw_key);
   if (set != ERROR_SUCCESS) {
     return std::unexpected{std::format("写入右键菜单注册表值失败，错误码 {}。", set)};
+  }
+  return {};
+}
+
+std::expected<void, std::string> delete_registry_tree(
+    HKEY root, std::wstring_view subkey) {
+  const std::wstring subkey_storage{subkey};
+  const auto deleted = RegDeleteTreeW(root, subkey_storage.c_str());
+  if (deleted != ERROR_SUCCESS && deleted != ERROR_FILE_NOT_FOUND &&
+      deleted != ERROR_PATH_NOT_FOUND) {
+    return std::unexpected{
+        std::format("移除右键菜单注册表失败，错误码 {}。", deleted)};
+  }
+  return {};
+}
+
+std::expected<std::filesystem::path, std::string> awj_exe_path_for_shell_menu();
+
+bool process_is_elevated() noexcept {
+  HANDLE token = nullptr;
+  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+    return false;
+  }
+  TOKEN_ELEVATION elevation{};
+  DWORD bytes = 0;
+  const bool elevated = GetTokenInformation(
+      token, TokenElevation, &elevation, sizeof(elevation), &bytes) != FALSE &&
+                        elevation.TokenIsElevated != 0;
+  CloseHandle(token);
+  return elevated;
+}
+
+std::expected<void, std::string> run_elevated_shell_context_menu_helper(
+    std::wstring_view operation) {
+  auto executable = awj_exe_path_for_shell_menu();
+  if (!executable) {
+    return std::unexpected{executable.error()};
+  }
+
+  std::wstring operation_storage{operation};
+  SHELLEXECUTEINFOW execute{};
+  execute.cbSize = sizeof(execute);
+  execute.fMask = SEE_MASK_NOCLOSEPROCESS;
+  execute.lpVerb = L"runas";
+  execute.lpFile = executable->c_str();
+  execute.lpParameters = operation_storage.c_str();
+  const auto working_directory = executable->parent_path();
+  execute.lpDirectory = working_directory.c_str();
+  execute.nShow = SW_HIDE;
+  if (!ShellExecuteExW(&execute)) {
+    const DWORD error = GetLastError();
+    if (error == ERROR_CANCELLED) {
+      return std::unexpected{"用户取消了管理员权限请求，右键菜单未修改。"};
+    }
+    return std::unexpected{std::format(
+        "请求管理员权限安装右键菜单失败，错误码 {}。", error)};
+  }
+
+  const DWORD wait = WaitForSingleObject(execute.hProcess, INFINITE);
+  if (wait != WAIT_OBJECT_0) {
+    const DWORD error = GetLastError();
+    CloseHandle(execute.hProcess);
+    return std::unexpected{std::format(
+        "等待右键菜单管理员操作失败，错误码 {}。", error)};
+  }
+  DWORD exit_code = 1;
+  const bool got_exit_code = GetExitCodeProcess(execute.hProcess, &exit_code) != FALSE;
+  CloseHandle(execute.hProcess);
+  if (!got_exit_code) {
+    return std::unexpected{"无法读取右键菜单管理员操作结果。"};
+  }
+  if (exit_code != 0) {
+    return std::unexpected{std::format(
+        "管理员权限右键菜单操作失败，退出码 {}。", exit_code)};
   }
   return {};
 }
@@ -3471,30 +3536,55 @@ std::wstring shell_extension_menu_key(std::wstring_view extension) {
   return std::format(L"Software\\Classes\\SystemFileAssociations\\{}\\shell\\AWJImage", extension);
 }
 
-std::expected<void, std::string> install_shell_subcommands(
-    std::wstring_view parent_key, const std::filesystem::path& awj_exe,
-    std::wstring_view icon_value,
+template <typename Callback>
+void for_each_shell_context_menu_parent(Callback&& callback) {
+  callback(shell_image_menu_key);
+  for (const auto extension : shell_supported_image_extensions) {
+    callback(shell_extension_menu_key(extension));
+  }
+  callback(shell_icofile_menu_key);
+  callback(shell_directory_menu_key);
+}
+
+bool registry_key_exists(HKEY root, std::wstring_view subkey);
+std::expected<void, std::string> remove_shell_context_menu_local();
+
+std::expected<void, std::string> install_shell_command_store(
+    const std::filesystem::path& awj_exe, std::wstring_view icon_value,
     const std::array<MenuFormatParams, 5>& menu_params) {
-  const auto shell_key = std::format(L"{}\\shell", parent_key);
   for (const auto& entry : shell_convert_commands) {
+    const auto command_store_key =
+        awj::ui::shell_command_store_verb_key(entry.key);
+    if (auto result = delete_registry_tree(HKEY_LOCAL_MACHINE,
+                                           command_store_key);
+        !result) {
+      return result;
+    }
     if (entry.append_png_suffix && !menu_params[0].install_avif_png_command) {
       continue;
     }
-    const auto verb_key = std::format(L"{}\\{}", shell_key, entry.key);
-    if (auto result = set_registry_string(HKEY_CURRENT_USER, verb_key, L"", entry.label); !result) {
+    if (auto result = set_registry_string(HKEY_LOCAL_MACHINE, command_store_key,
+                                           L"", entry.label);
+        !result) {
       return result;
     }
-    if (auto result = set_registry_string(HKEY_CURRENT_USER, verb_key, L"MUIVerb", entry.label); !result) {
+    if (auto result = set_registry_string(HKEY_LOCAL_MACHINE, command_store_key,
+                                           L"MUIVerb", entry.label);
+        !result) {
       return result;
     }
-    if (auto result = set_registry_string(HKEY_CURRENT_USER, verb_key, L"Icon", icon_value); !result) {
+    if (auto result = set_registry_string(HKEY_LOCAL_MACHINE, command_store_key,
+                                           L"Icon", icon_value);
+        !result) {
       return result;
     }
-    if (auto result = set_registry_string(HKEY_CURRENT_USER, verb_key, L"MultiSelectModel", L"Player"); !result) {
+    if (auto result = set_registry_string(HKEY_LOCAL_MACHINE, command_store_key,
+                                           L"MultiSelectModel", L"Player");
+        !result) {
       return result;
     }
-    const auto command_key = verb_key + L"\\command";
-    if (auto result = set_registry_string(HKEY_CURRENT_USER, command_key, L"",
+    const auto command_key = command_store_key + L"\\command";
+    if (auto result = set_registry_string(HKEY_LOCAL_MACHINE, command_key, L"",
                                           shell_convert_command_line(awj_exe, entry.format, menu_params[menu_param_index_for_format(entry.format)], entry.append_png_suffix)); !result) {
       return result;
     }
@@ -3502,71 +3592,137 @@ std::expected<void, std::string> install_shell_subcommands(
   return {};
 }
 
+std::expected<void, std::string> remove_shell_command_store_entries(
+    HKEY root) {
+  for (const auto& entry : shell_convert_commands) {
+    if (auto result = delete_registry_tree(
+            root, awj::ui::shell_command_store_verb_key(entry.key));
+        !result) {
+      return result;
+    }
+  }
+  return {};
+}
+
 std::expected<void, std::string> install_shell_context_menu_for(
-    std::wstring_view parent_key, const std::filesystem::path& awj_exe,
-    std::wstring_view icon_value,
-    const std::array<MenuFormatParams, 5>& menu_params) {
-  RegDeleteTreeW(HKEY_CURRENT_USER, std::wstring{parent_key}.c_str());
-  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key, L"MUIVerb", L"AWJimage 转换"); !result) {
+    std::wstring_view parent_key, std::wstring_view icon_value,
+    bool install_avif_png_command) {
+  if (auto result = delete_registry_tree(HKEY_CURRENT_USER, parent_key);
+      !result) {
     return result;
   }
-  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key, L"Icon", icon_value); !result) {
+  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key,
+                                        L"MUIVerb", L"AWJimage 转换");
+      !result) {
     return result;
   }
-  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key, L"SubCommands", L""); !result) {
+  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key, L"Icon",
+                                        icon_value);
+      !result) {
     return result;
   }
-  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key, L"MultiSelectModel", L"Player"); !result) {
+  if (auto result = set_registry_string(
+          HKEY_CURRENT_USER, parent_key, L"SubCommands",
+          awj::ui::shell_context_menu_subcommands(
+              install_avif_png_command));
+      !result) {
     return result;
   }
-  if (auto result = install_shell_subcommands(parent_key, awj_exe, icon_value, menu_params); !result) {
+  if (auto result = set_registry_string(HKEY_CURRENT_USER, parent_key,
+                                        L"MultiSelectModel", L"Player");
+      !result) {
     return result;
   }
   return {};
 }
 
-std::expected<void, std::string> install_shell_context_menu(const std::array<MenuFormatParams, 5>& menu_params) {
+std::expected<void, std::string> install_shell_context_menu_local(
+    const std::array<MenuFormatParams, 5>& menu_params) {
   auto awj_exe = awj_exe_path_for_shell_menu();
   if (!awj_exe) {
     return std::unexpected{awj_exe.error()};
   }
   const auto icon_value = shell_menu_icon_value(*awj_exe);
-  RegDeleteTreeW(HKEY_CURRENT_USER, std::wstring{shell_legacy_subcommands_key}.c_str());
-  if (auto result = install_shell_context_menu_for(shell_image_menu_key, *awj_exe, icon_value, menu_params); !result) {
+  if (auto result = delete_registry_tree(HKEY_CURRENT_USER,
+                                         shell_legacy_subcommands_key);
+      !result) {
     return result;
   }
-  for (const auto extension : shell_supported_image_extensions) {
-    const auto key = shell_extension_menu_key(extension);
-    if (auto result = install_shell_context_menu_for(key, *awj_exe, icon_value, menu_params); !result) {
-      return result;
-    }
-  }
-  if (auto result = install_shell_context_menu_for(shell_icofile_menu_key, *awj_exe, icon_value, menu_params); !result) {
+  if (auto result = install_shell_command_store(*awj_exe, icon_value,
+                                                menu_params);
+      !result) {
     return result;
   }
-  if (auto result = install_shell_context_menu_for(shell_directory_menu_key, *awj_exe, icon_value, menu_params); !result) {
+  if (auto result = remove_shell_command_store_entries(HKEY_CURRENT_USER);
+      !result) {
     return result;
   }
+  std::expected<void, std::string> result{};
+  for_each_shell_context_menu_parent([&](std::wstring_view parent_key) {
+    if (!result) return;
+    result = install_shell_context_menu_for(
+        parent_key, icon_value, menu_params[0].install_avif_png_command);
+  });
+  if (!result) return result;
   SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
   return {};
+}
+
+std::expected<void, std::string> install_shell_context_menu(
+    const std::array<MenuFormatParams, 5>& menu_params) {
+  if (!process_is_elevated()) {
+    return run_elevated_shell_context_menu_helper(
+        L"--shell-context-menu-helper");
+  }
+  return install_shell_context_menu_local(menu_params);
 }
 
 std::expected<void, std::string> remove_shell_context_menu() {
-  RegDeleteTreeW(HKEY_CURRENT_USER, std::wstring{shell_image_menu_key}.c_str());
-  for (const auto extension : shell_supported_image_extensions) {
-    const auto key = shell_extension_menu_key(extension);
-    RegDeleteTreeW(HKEY_CURRENT_USER, key.c_str());
+  bool machine_registration_exists = false;
+  for (const auto& entry : shell_convert_commands) {
+    machine_registration_exists =
+        machine_registration_exists || registry_key_exists(
+                                          HKEY_LOCAL_MACHINE,
+                                          awj::ui::shell_command_store_verb_key(
+                                              entry.key));
   }
-  RegDeleteTreeW(HKEY_CURRENT_USER, std::wstring{shell_icofile_menu_key}.c_str());
-  RegDeleteTreeW(HKEY_CURRENT_USER, std::wstring{shell_directory_menu_key}.c_str());
-  RegDeleteTreeW(HKEY_CURRENT_USER, std::wstring{shell_legacy_subcommands_key}.c_str());
+  if (machine_registration_exists && !process_is_elevated()) {
+    return run_elevated_shell_context_menu_helper(
+        L"--shell-context-menu-remove-helper");
+  }
+
+  return remove_shell_context_menu_local();
+}
+
+std::expected<void, std::string> remove_shell_context_menu_local() {
+  std::optional<std::string> first_error;
+  const auto remove_one = [&](std::wstring_view key) {
+    if (auto result = delete_registry_tree(HKEY_CURRENT_USER, key); !result) {
+      if (!first_error) first_error = result.error();
+    }
+  };
+  for_each_shell_context_menu_parent(remove_one);
+  for (const auto& entry : shell_convert_commands) {
+    remove_one(awj::ui::shell_command_store_verb_key(entry.key));
+  }
+  remove_one(shell_legacy_subcommands_key);
+  for (const auto& entry : shell_convert_commands) {
+    if (auto result = delete_registry_tree(
+            HKEY_LOCAL_MACHINE,
+            awj::ui::shell_command_store_verb_key(entry.key));
+        !result && !first_error) {
+      first_error = result.error();
+    }
+  }
+  if (first_error) return std::unexpected{*first_error};
   SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
   return {};
 }
 
-bool registry_key_exists(std::wstring_view subkey) {
+bool registry_key_exists(HKEY root, std::wstring_view subkey) {
+  const std::wstring subkey_storage{subkey};
   HKEY raw_key = nullptr;
-  const auto opened = RegOpenKeyExW(HKEY_CURRENT_USER, std::wstring{subkey}.c_str(),
+  const auto opened = RegOpenKeyExW(root, subkey_storage.c_str(),
                                     0, KEY_READ, &raw_key);
   if (opened != ERROR_SUCCESS) {
     return false;
@@ -3575,8 +3731,8 @@ bool registry_key_exists(std::wstring_view subkey) {
   return true;
 }
 
-std::optional<std::wstring> registry_string_value(std::wstring_view subkey,
-                                                  std::wstring_view value_name) {
+std::optional<std::wstring> registry_string_value(
+    HKEY root, std::wstring_view subkey, std::wstring_view value_name) {
   std::wstring subkey_storage{subkey};
   std::wstring name_storage;
   const wchar_t* name = nullptr;
@@ -3586,13 +3742,13 @@ std::optional<std::wstring> registry_string_value(std::wstring_view subkey,
   }
   DWORD type = 0;
   DWORD bytes = 0;
-  const auto query = RegGetValueW(HKEY_CURRENT_USER, subkey_storage.c_str(),
+  const auto query = RegGetValueW(root, subkey_storage.c_str(),
                                   name, RRF_RT_REG_SZ, &type, nullptr, &bytes);
   if (query != ERROR_SUCCESS || bytes < sizeof(wchar_t)) {
     return std::nullopt;
   }
   std::wstring value(bytes / sizeof(wchar_t), L'\0');
-  const auto read = RegGetValueW(HKEY_CURRENT_USER, subkey_storage.c_str(),
+  const auto read = RegGetValueW(root, subkey_storage.c_str(),
                                  name, RRF_RT_REG_SZ, &type, value.data(), &bytes);
   if (read != ERROR_SUCCESS) {
     return std::nullopt;
@@ -3603,39 +3759,96 @@ std::optional<std::wstring> registry_string_value(std::wstring_view subkey,
   return value;
 }
 
+bool shell_context_menu_registration_exists() {
+  bool found = registry_key_exists(HKEY_CURRENT_USER,
+                                   shell_legacy_subcommands_key);
+  for_each_shell_context_menu_parent([&](std::wstring_view parent_key) {
+    found = found || registry_key_exists(HKEY_CURRENT_USER, parent_key);
+  });
+  for (const auto& entry : shell_convert_commands) {
+    found = found || registry_key_exists(
+                         HKEY_CURRENT_USER,
+                         awj::ui::shell_command_store_verb_key(entry.key));
+    found = found || registry_key_exists(
+                         HKEY_LOCAL_MACHINE,
+                         awj::ui::shell_command_store_verb_key(entry.key));
+  }
+  return found;
+}
+
 std::optional<std::string> shell_context_menu_warning(
     const std::array<MenuFormatParams, 5>& menu_params) {
-  if (!registry_key_exists(shell_image_menu_key) &&
-      !registry_key_exists(shell_icofile_menu_key) &&
-      !registry_key_exists(shell_directory_menu_key) &&
-      !registry_key_exists(shell_legacy_subcommands_key)) {
+  if (!shell_context_menu_registration_exists()) {
     return std::nullopt;
   }
-  if (registry_key_exists(shell_legacy_subcommands_key)) {
-    return "检测到旧版右键菜单，点击移除后重新安装。";
+  if (registry_key_exists(HKEY_CURRENT_USER, shell_legacy_subcommands_key)) {
+    return "检测到旧版右键菜单或兼容性残留，点击移除后重新安装。";
   }
   auto awj_exe = awj_exe_path_for_shell_menu();
   if (!awj_exe) {
     return "无法检查右键菜单程序路径，请移除后重新安装。";
   }
-  const auto command_key = std::format(L"{}\\shell\\avif\\command", shell_image_menu_key);
-  const auto command = registry_string_value(command_key, L"");
-  const auto expected = shell_convert_command_line(*awj_exe, L"avif", menu_params[0]);
-  const auto multi = registry_string_value(shell_image_menu_key, L"MultiSelectModel");
-  if (!command || *command != expected || !multi || *multi != L"Player") {
-    return "右键菜单与当前版本/菜单参数不一致，点击移除旧菜单。";
-  }
-  const auto png_key =
-      std::format(L"{}\\shell\\avif-png\\command", shell_image_menu_key);
-  const auto png_command = registry_string_value(png_key, L"");
-  if (menu_params[0].install_avif_png_command) {
-    const auto png_expected =
-        shell_convert_command_line(*awj_exe, L"avif", menu_params[0], true);
-    if (!png_command || *png_command != png_expected) {
-      return "右键菜单与当前 AVIF.png 设置不一致，请重新安装右键菜单。";
+  const auto icon_value = shell_menu_icon_value(*awj_exe);
+  const auto expected_subcommands = awj::ui::shell_context_menu_subcommands(
+      menu_params[0].install_avif_png_command);
+  std::optional<std::string> parent_warning;
+  for_each_shell_context_menu_parent([&](std::wstring_view parent_key) {
+    if (parent_warning) return;
+    if (!registry_key_exists(HKEY_CURRENT_USER, parent_key)) {
+      parent_warning = "右键菜单注册不完整，请移除后重新安装。";
+      return;
     }
-  } else if (png_command) {
-    return "右键菜单仍含 AVIF.png 命令，请重新安装右键菜单。";
+    const auto inline_shell_key = std::format(L"{}\\shell", parent_key);
+    if (registry_key_exists(HKEY_CURRENT_USER, inline_shell_key)) {
+      parent_warning = "检测到旧版内联子菜单结构，请移除后重新安装。";
+      return;
+    }
+    const auto label = registry_string_value(HKEY_CURRENT_USER, parent_key, L"");
+    const auto mui = registry_string_value(HKEY_CURRENT_USER, parent_key, L"MUIVerb");
+    const auto icon = registry_string_value(HKEY_CURRENT_USER, parent_key, L"Icon");
+    const auto subcommands = registry_string_value(HKEY_CURRENT_USER, parent_key, L"SubCommands");
+    const auto multi = registry_string_value(HKEY_CURRENT_USER, parent_key, L"MultiSelectModel");
+    if (label || !mui || *mui != L"AWJimage 转换" ||
+        !icon || *icon != icon_value ||
+        !subcommands || *subcommands != expected_subcommands ||
+        !multi || *multi != L"Player" ||
+        registry_key_exists(HKEY_CURRENT_USER,
+                            std::wstring{parent_key} + L"\\command")) {
+      parent_warning = "右键菜单与当前版本/菜单参数不一致，请移除后重新安装。";
+    }
+  });
+  if (parent_warning) return parent_warning;
+
+  for (const auto& entry : shell_convert_commands) {
+    const auto command_store_key =
+        awj::ui::shell_command_store_verb_key(entry.key);
+    const bool enabled =
+        !entry.append_png_suffix || menu_params[0].install_avif_png_command;
+    if (!enabled) {
+      if (registry_key_exists(HKEY_LOCAL_MACHINE, command_store_key) ||
+          registry_key_exists(HKEY_CURRENT_USER, command_store_key)) {
+        return "右键菜单仍含已停用的 AVIF.png 命令，请重新安装。";
+      }
+      continue;
+    }
+    const auto command_key = command_store_key + L"\\command";
+    const auto command = registry_string_value(HKEY_LOCAL_MACHINE, command_key, L"");
+    const auto expected = shell_convert_command_line(
+        *awj_exe, entry.format,
+        menu_params[menu_param_index_for_format(entry.format)],
+        entry.append_png_suffix);
+    const auto label = registry_string_value(HKEY_LOCAL_MACHINE, command_store_key, L"");
+    const auto mui = registry_string_value(HKEY_LOCAL_MACHINE, command_store_key, L"MUIVerb");
+    const auto icon = registry_string_value(HKEY_LOCAL_MACHINE, command_store_key, L"Icon");
+    const auto multi =
+        registry_string_value(HKEY_LOCAL_MACHINE, command_store_key, L"MultiSelectModel");
+    if (!registry_key_exists(HKEY_LOCAL_MACHINE, command_store_key) ||
+        registry_key_exists(HKEY_CURRENT_USER, command_store_key) ||
+        !command || *command != expected ||
+        !label || *label != entry.label || !mui || *mui != entry.label ||
+        !icon || *icon != icon_value || !multi || *multi != L"Player") {
+      return "右键菜单子命令与当前版本/菜单参数不一致，请移除后重新安装。";
+    }
   }
   return std::nullopt;
 }
@@ -6266,6 +6479,72 @@ void start_update_check(slint::ComponentWeakHandle<AwjStudio> weak,
 }
 
 }  // namespace
+
+int run_shell_context_menu_helper(int argc, wchar_t* argv[]) {
+  if (argc != 2 || argv == nullptr || argv[1] == nullptr) {
+    return 2;
+  }
+
+  if (std::wcscmp(argv[1], L"--shell-context-menu-helper") == 0) {
+    std::array<MenuFormatParams, 5> menu_params{};
+    for (int index = 0; index < static_cast<int>(menu_params.size()); ++index) {
+      menu_params[static_cast<std::size_t>(index)] =
+          default_menu_params_for_index(index);
+    }
+
+    const auto config_path = studio_config_path();
+    if (!config_path.empty()) {
+      std::error_code ec;
+      if (std::filesystem::exists(config_path, ec) && !ec) {
+        std::ifstream input{config_path, std::ios::binary};
+        std::string source{std::istreambuf_iterator<char>{input},
+                           std::istreambuf_iterator<char>{}};
+        if (!input) {
+          MessageBoxW(nullptr, L"无法读取 Studio 配置文件，右键菜单未安装。",
+                      L"AWJimage", MB_OK | MB_ICONERROR);
+          return 1;
+        }
+        auto values = parse_jsonc_config(source);
+        if (!values) {
+          MessageBoxW(nullptr, awj::wide_from_utf8(values.error()).c_str(),
+                      L"AWJimage", MB_OK | MB_ICONERROR);
+          return 1;
+        }
+        if (auto applied = apply_menu_config_values(*values, menu_params);
+            !applied) {
+          MessageBoxW(nullptr, awj::wide_from_utf8(applied.error()).c_str(),
+                      L"AWJimage", MB_OK | MB_ICONERROR);
+          return 1;
+        }
+      }
+    }
+
+    if (auto valid = validate_menu_params(menu_params); !valid) {
+      MessageBoxW(nullptr, awj::wide_from_utf8(valid.error()).c_str(),
+                  L"AWJimage", MB_OK | MB_ICONERROR);
+      return 1;
+    }
+    auto installed = install_shell_context_menu_local(menu_params);
+    if (!installed) {
+      MessageBoxW(nullptr, awj::wide_from_utf8(installed.error()).c_str(),
+                  L"AWJimage", MB_OK | MB_ICONERROR);
+      return 1;
+    }
+    return 0;
+  }
+
+  if (std::wcscmp(argv[1], L"--shell-context-menu-remove-helper") == 0) {
+    auto removed = remove_shell_context_menu_local();
+    if (!removed) {
+      MessageBoxW(nullptr, awj::wide_from_utf8(removed.error()).c_str(),
+                  L"AWJimage", MB_OK | MB_ICONERROR);
+      return 1;
+    }
+    return 0;
+  }
+
+  return 2;
+}
 
 /// Probe whether the OpenGL driver exposes the functions FemtoVG needs
 /// (glCreateShader, OpenGL 2.0+). If not, force Slint to use the software

--- a/src/ui/shell_context_menu.h
+++ b/src/ui/shell_context_menu.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace awj::ui {
+
+struct ShellContextMenuCommand {
+  std::wstring_view key{};
+  std::wstring_view label{};
+  std::wstring_view format{};
+  bool append_png_suffix{};
+};
+
+inline constexpr std::wstring_view shell_image_menu_key =
+    L"Software\\Classes\\SystemFileAssociations\\image\\shell\\AWJImage";
+inline constexpr std::wstring_view shell_icofile_menu_key =
+    L"Software\\Classes\\icofile\\shell\\AWJImage";
+inline constexpr std::wstring_view shell_directory_menu_key =
+    L"Software\\Classes\\Directory\\shell\\AWJImage";
+inline constexpr std::wstring_view shell_legacy_subcommands_key =
+    L"Software\\Classes\\AWJImage.ContextMenu";
+inline constexpr std::wstring_view shell_command_store_shell_key =
+    L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CommandStore\\shell";
+inline constexpr std::wstring_view shell_command_store_prefix = L"AWJImage.";
+
+inline constexpr std::array<ShellContextMenuCommand, 6>
+    shell_context_menu_commands = {{
+        {.key = L"png", .label = L"转换为 PNG", .format = L"png"},
+        {.key = L"webp", .label = L"转换为 WebP", .format = L"webp"},
+        {.key = L"avif", .label = L"转换为 AVIF", .format = L"avif"},
+        {.key = L"avif-png", .label = L"转换为 AVIF.png", .format = L"avif", .append_png_suffix = true},
+        {.key = L"jxl", .label = L"转换为 JXL", .format = L"jxl"},
+        {.key = L"jpgli", .label = L"转换为 JPGLI", .format = L"jpgli"},
+    }};
+
+inline std::wstring shell_command_store_verb_name(
+    std::wstring_view command_key) {
+  return std::wstring{shell_command_store_prefix} +
+         std::wstring{command_key};
+}
+
+inline std::wstring shell_command_store_verb_key(
+    std::wstring_view command_key) {
+  return std::wstring{shell_command_store_shell_key} + L"\\" +
+         shell_command_store_verb_name(command_key);
+}
+
+inline std::wstring shell_context_menu_subcommands(
+    bool install_avif_png_command) {
+  std::wstring value;
+  bool first = true;
+  for (const auto& command : shell_context_menu_commands) {
+    if (command.append_png_suffix && !install_avif_png_command) continue;
+    if (!first) value.push_back(L';');
+    value += shell_command_store_verb_name(command.key);
+    first = false;
+  }
+  return value;
+}
+
+}  // namespace awj::ui
+
+#endif  // _WIN32

--- a/tests/hdr_tonemap_tests.cpp
+++ b/tests/hdr_tonemap_tests.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <iostream>
 #include <string_view>
+#include <vector>
 
 import awj.hdr_tonemap;
 import awj.image;
@@ -55,7 +56,8 @@ int main() {
   auto sdr = awj::hdr::tone_map_to_sdr_srgb(source);
   if (!sdr || sdr->bit_depth != 8 ||
       sdr->sample_representation != awj::SampleRepresentation::unorm ||
-      !sdr->source_info || sdr->source_info->transfer_characteristics != 13 ||
+      !sdr->source_info ||
+      sdr->source_info->transfer_characteristics.value_or(-1) != 13 ||
       sdr->planes.size() != 1 || sdr->planes.front().bytes.size() != 4 ||
       sdr->planes.front().bytes[3] != std::byte{255}) {
     return fail(sdr ? "scRGB tone mapping output metadata or alpha is invalid."
@@ -65,9 +67,10 @@ int main() {
   auto hdr10 = awj::hdr::materialize_scrgb_as_hdr10(source);
   if (!hdr10 || hdr10->bit_depth != 16 ||
       hdr10->sample_representation != awj::SampleRepresentation::unorm ||
-      !hdr10->source_info || hdr10->source_info->color_primaries != 9 ||
-      hdr10->source_info->transfer_characteristics != 16 ||
-      hdr10->source_info->matrix_coefficients != 9) {
+      !hdr10->source_info ||
+      hdr10->source_info->color_primaries.value_or(-1) != 9 ||
+      hdr10->source_info->transfer_characteristics.value_or(-1) != 16 ||
+      hdr10->source_info->matrix_coefficients.value_or(-1) != 9) {
     return fail(hdr10 ? "scRGB HDR materialization metadata is invalid."
                       : hdr10.error());
   }

--- a/tests/shell_context_menu_tests.cpp
+++ b/tests/shell_context_menu_tests.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <string_view>
+
+#include "shell_context_menu.h"
+
+namespace {
+
+int fail(const char* message) {
+  std::cerr << message << '\n';
+  return 1;
+}
+
+}  // namespace
+
+int main() {
+  using awj::ui::shell_command_store_verb_key;
+  using awj::ui::shell_command_store_verb_name;
+  using awj::ui::shell_context_menu_subcommands;
+
+  if (shell_command_store_verb_name(L"avif") != L"AWJImage.avif") {
+    return fail("CommandStore verb name changed unexpectedly.");
+  }
+  if (shell_command_store_verb_key(L"avif") !=
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\CommandStore\\shell\\AWJImage.avif") {
+    return fail("CommandStore verb registry path changed unexpectedly.");
+  }
+
+  constexpr std::wstring_view without_png_suffix =
+      L"AWJImage.png;AWJImage.webp;AWJImage.avif;AWJImage.jxl;AWJImage.jpgli";
+  constexpr std::wstring_view with_png_suffix =
+      L"AWJImage.png;AWJImage.webp;AWJImage.avif;AWJImage.avif-png;AWJImage.jxl;AWJImage.jpgli";
+  if (shell_context_menu_subcommands(false) != without_png_suffix ||
+      shell_context_menu_subcommands(true) != with_png_suffix) {
+    return fail("SubCommands list does not match the enabled formats.");
+  }
+  return 0;
+}


### PR DESCRIPTION
## Problem

On Windows, dragging files from Explorer into AWJ's input or output fields placed the drop event at the wrong UI position under DPI scaling. Windows Winit's OLE `DroppedFile` event can arrive without a preceding `CursorMoved`, so the buffered `self.cursor_pos` was stale.

## Fix

- Capture `GetCursorPos` at drop time and subtract `winit_window.inner_position()` to get client-area physical coordinates.
- Convert using `winit_window.scale_factor()` (not the Slint runtime's `runtime_window.scale_factor()`) so the Slint `DropArea` hit test matches the actual cursor position.
- Batch all paths from a single multi-file drop with the same position and dispatch them after flushing pending mouse moves in `about_to_wait`.
- Add `Win32_Foundation` feature to the Winit backend's Windows dependencies for `POINT` / `GetCursorPos`.
- Make the patch migration idempotent: replace the old expression only when present and skip silently when already migrated, avoiding a fatal error from broad `runtime_window.scale_factor` matches in unrelated event handlers.

## Testing

- `cmake --build build/x64/Release --config Release --target AWJ awj_ui_smoke_tests` — passed.
- `awj_ui_smoke_tests.exe` exit code 0.
- `git diff --check` passed.
- Manual drag-and-drop verified from Windows Explorer and Directory Opus into AWJ input/output fields under a 150% DPI display.
- Patch script rerun is idempotent (exit code 0 on second invocation).