### PR TITLE
fix: use winit scale factor for native file drop position

### DIFF
--- a/cmake/patch_slint_static_import.cmake
+++ b/cmake/patch_slint_static_import.cmake
@@ -22,14 +22,116 @@ endif()
 file(TOUCH "${SOURCE_DIR}/api/cpp/build.rs")
 
 # Slint 1.17 exposes DropArea/DataTransfer, while its Winit backend currently
-# leaves Winit's native DroppedFile events untranslated.  AWJ needs the public
+# leaves Winit's native DroppedFile events untranslated. AWJ needs the public
 # DropArea path on both desktop platforms, not a Win32 WM_DROPFILES shim.
 set(WINIT_EVENT_LOOP "${SOURCE_DIR}/internal/backends/winit/event_loop.rs")
 if(NOT EXISTS "${WINIT_EVENT_LOOP}")
     message(FATAL_ERROR "Slint Winit event loop source not found.")
 endif()
+
+# The native-drop position helper uses POINT on Windows. Keep the dependency
+# explicit instead of relying on feature unification from another Slint crate.
+set(WINIT_CARGO_TOML "${SOURCE_DIR}/internal/backends/winit/Cargo.toml")
+if(NOT EXISTS "${WINIT_CARGO_TOML}")
+    message(FATAL_ERROR "Slint Winit Cargo.toml not found.")
+endif()
+file(READ "${WINIT_CARGO_TOML}" WINIT_CARGO_CONTENT)
+if(NOT WINIT_CARGO_CONTENT MATCHES "Win32_Foundation")
+    string(REPLACE
+        "windows = { workspace = true, features = [\"Win32_UI_WindowsAndMessaging\", \"Win32_UI_HiDpi\", \"Win32_Graphics_Gdi\", \"Win32_Graphics_Dwm\"] }"
+        "windows = { workspace = true, features = [\"Win32_Foundation\", \"Win32_UI_WindowsAndMessaging\", \"Win32_UI_HiDpi\", \"Win32_Graphics_Gdi\", \"Win32_Graphics_Dwm\"] }"
+        WINIT_CARGO_PATCHED "${WINIT_CARGO_CONTENT}")
+    if(WINIT_CARGO_PATCHED STREQUAL WINIT_CARGO_CONTENT)
+        message(FATAL_ERROR "Could not add the Slint Winit Windows foundation feature.")
+    endif()
+    file(WRITE "${WINIT_CARGO_TOML}" "${WINIT_CARGO_PATCHED}")
+endif()
+
 file(READ "${WINIT_EVENT_LOOP}" WINIT_CONTENT)
-if(NOT WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V2")
+# V3 was briefly generated before native file drops retained their exact
+# position. Upgrade those already-patched build trees before deciding whether a
+# full patch is needed.
+if(WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V3" AND
+   NOT WINIT_CONTENT MATCHES "fallback_position = self.cursor_pos")
+    set(WINIT_V3_OLD_DROP_EVENT
+        "            WindowEvent::DroppedFile(path) => {\n                let fallback_position = self.cursor_pos;\n                let position = window\n                    .winit_window()\n                    .map(|winit_window| {\n                        native_file_drop_position(\n                            &winit_window,\n                            winit_window.scale_factor(),\n                            fallback_position,\n                        )\n                    })\n                    .unwrap_or(fallback_position);\n                self.cursor_pos = position;\n                self.pending_native_file_drops.push((window_id, path, position));\n            }")
+    set(WINIT_V3_NEW_DROP_EVENT
+        "            WindowEvent::DroppedFile(path) => {\n                let fallback_position = self.cursor_pos;\n                let position = window\n                    .winit_window()\n                    .map(|winit_window| {\n                        native_file_drop_position(\n                            &winit_window,\n                            runtime_window.scale_factor() as f64,\n                            fallback_position,\n                        )\n                    })\n                    .unwrap_or(fallback_position);\n                self.cursor_pos = position;\n                self.pending_native_file_drops.push((window_id, path, position));\n            }")
+    string(REPLACE "${WINIT_V3_OLD_DROP_EVENT}" "${WINIT_V3_NEW_DROP_EVENT}"
+        WINIT_PATCHED "${WINIT_CONTENT}")
+    string(REPLACE
+        "let logical_position = physical_position.to_logical(scale_factor);"
+        "let logical_position = physical_position.to_logical::<corelib::Coord>(scale_factor);"
+        WINIT_PATCHED "${WINIT_PATCHED}")
+    string(REPLACE
+        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_native_file_drops();\n        self.flush_pending_mouse_move();"
+        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_mouse_move();\n        self.flush_pending_native_file_drops();"
+        WINIT_PATCHED "${WINIT_PATCHED}")
+    if(WINIT_PATCHED STREQUAL WINIT_CONTENT)
+        message(FATAL_ERROR "Could not upgrade the existing Slint native-drop patch.")
+    endif()
+    file(WRITE "${WINIT_EVENT_LOOP}" "${WINIT_PATCHED}")
+    set(WINIT_CONTENT "${WINIT_PATCHED}")
+endif()
+if(WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V3")
+    # Idempotent DPI migration: if the old scale source is present, replace it.
+    # If absent, the tree is already migrated and the replace is a no-op.
+    string(REPLACE
+        "                            runtime_window.scale_factor() as f64,"
+        "                            winit_window.scale_factor(),"
+        WINIT_PATCHED "${WINIT_CONTENT}")
+    if(NOT WINIT_PATCHED STREQUAL WINIT_CONTENT)
+        file(WRITE "${WINIT_EVENT_LOOP}" "${WINIT_PATCHED}")
+        set(WINIT_CONTENT "${WINIT_PATCHED}")
+    endif()
+endif()
+if(NOT WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V3")
+    set(WINIT_NATIVE_DROP_POSITION "\nfn native_file_drop_position(\n    window: &winit::window::Window,\n    scale_factor: f64,\n    fallback: LogicalPoint,\n) -> LogicalPoint {\n    #[cfg(target_os = \"windows\")]\n    {\n        use windows::Win32::Foundation::POINT;\n        use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;\n\n        let mut screen_position = POINT::default();\n        if unsafe { GetCursorPos(&mut screen_position) }.is_ok() {\n            if let Ok(client_origin) = window.inner_position() {\n                let physical_position = winit::dpi::PhysicalPosition::new(\n                    screen_position.x - client_origin.x,\n                    screen_position.y - client_origin.y,\n                );\n                let logical_position = physical_position.to_logical::<corelib::Coord>(scale_factor);\n                return euclid::point2(logical_position.x, logical_position.y);\n            }\n        }\n    }\n    #[cfg(not(target_os = \"windows\"))]\n    let _ = (window, scale_factor);\n    fallback\n}\n")
+    set(WINIT_DROPPED_FILE_EVENT "            WindowEvent::DroppedFile(path) => {\n                let fallback_position = self.cursor_pos;\n                let position = window\n                    .winit_window()\n                    .map(|winit_window| {\n                        native_file_drop_position(\n                            &winit_window,\n                            winit_window.scale_factor(),\n                            fallback_position,\n                        )\n                    })\n                    .unwrap_or(fallback_position);\n                self.cursor_pos = position;\n                self.pending_native_file_drops.push((window_id, path, position));\n            }\n")
+
+    # Support reconfiguration of an existing build tree that contains the
+    # previous V2 patch, as well as pristine Slint sources in a fresh build.
+    if(WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V2")
+        set(WINIT_PATCHED "${WINIT_CONTENT}")
+        string(REPLACE "AWJ_NATIVE_FILE_DND_V2" "AWJ_NATIVE_FILE_DND_V3"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf)>,"
+            "pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf, LogicalPoint)>,"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "use winit::keyboard::Key;\n"
+            "use winit::keyboard::Key;${WINIT_NATIVE_DROP_POSITION}\n"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "        for (window_id, path) in pending {"
+            "        for (window_id, path, position) in pending {"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "        let mut grouped: Vec<(winit::window::WindowId, String)> = Vec::new();"
+            "        let mut grouped: Vec<(winit::window::WindowId, LogicalPoint, String)> = Vec::new();"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "if let Some((_, paths)) = grouped.iter_mut().find(|(id, _)| *id == window_id)"
+            "if let Some((_, _, paths)) = grouped.iter_mut().find(|(id, _, _)| *id == window_id)"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "                grouped.push((window_id, path.to_string_lossy().into_owned()));"
+            "                grouped.push((window_id, position, path.to_string_lossy().into_owned()));"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "        for (window_id, paths) in grouped {"
+            "        for (window_id, position, paths) in grouped {"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "event.position = corelib::api::LogicalPosition::new(self.cursor_pos.x, self.cursor_pos.y);"
+            "event.position = corelib::api::LogicalPosition::new(position.x, position.y);"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+        string(REPLACE
+            "            WindowEvent::DroppedFile(path) => {\n                self.pending_native_file_drops.push((window_id, path));\n            }\n"
+            "${WINIT_DROPPED_FILE_EVENT}"
+            WINIT_PATCHED "${WINIT_PATCHED}")
+    else()
     string(REPLACE
         "use corelib::SharedString;\nuse corelib::graphics::euclid;\nuse corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};\nuse corelib::items::{ColorScheme, PointerEventButton};"
         "use corelib::SharedString;\nuse corelib::DataTransfer;\nuse corelib::graphics::euclid;\nuse corelib::input::{InternalKeyEvent, KeyEvent, KeyEventType, MouseEvent, TouchPhase};\nuse corelib::items::{AllowedDragActions, ColorScheme, DragAction, DropEvent, PointerEventButton};"
@@ -39,25 +141,36 @@ if(NOT WINIT_CONTENT MATCHES "AWJ_NATIVE_FILE_DND_V2")
     endif()
     string(REPLACE
         "    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,"
-        "    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,\n\n    // AWJ_NATIVE_FILE_DND_V2: batch paths reported in one native Winit turn.\n    pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf)>,"
+        "    pending_mouse_move: Option<(winit::window::WindowId, LogicalPoint)>,\n\n    // AWJ_NATIVE_FILE_DND_V3: batch paths and the native drop position.\n    pending_native_file_drops: Vec<(winit::window::WindowId, std::path::PathBuf, LogicalPoint)>,"
         WINIT_PATCHED "${WINIT_PATCHED}")
     string(REPLACE
         "            pending_mouse_move: Default::default(),"
         "            pending_mouse_move: Default::default(),\n            pending_native_file_drops: Default::default(),"
         WINIT_PATCHED "${WINIT_PATCHED}")
-    set(WINIT_FLUSH_NATIVE "\n    fn flush_pending_native_file_drops(&mut self) {\n        let pending = std::mem::take(&mut self.pending_native_file_drops);\n        let mut grouped: Vec<(winit::window::WindowId, String)> = Vec::new();\n        for (window_id, path) in pending {\n            if let Some((_, paths)) = grouped.iter_mut().find(|(id, _)| *id == window_id) {\n                if !paths.is_empty() { paths.push('\\n'); }\n                paths.push_str(&path.to_string_lossy());\n            } else {\n                grouped.push((window_id, path.to_string_lossy().into_owned()));\n            }\n        }\n        for (window_id, paths) in grouped {\n            let Some(window) = self.shared_backend_data.window_by_id(window_id) else { continue; };\n            let runtime_window = WindowInner::from_pub(window.window());\n            let mut data = DataTransfer::default();\n            data.set_plain_text(paths.into());\n            let mut event = DropEvent::default();\n            event.data = data;\n            event.position = corelib::api::LogicalPosition::new(self.cursor_pos.x, self.cursor_pos.y);\n            event.proposed_action = DragAction::Copy;\n            let allowed = AllowedDragActions { copy: true, move_: false, link: false };\n            runtime_window.process_mouse_input(MouseEvent::DragMove { event: event.clone(), allowed });\n            runtime_window.process_mouse_input(MouseEvent::Drop { event, allowed });\n        }\n    }\n")
+    string(REPLACE
+        "use winit::keyboard::Key;\n"
+        "use winit::keyboard::Key;${WINIT_NATIVE_DROP_POSITION}\n"
+        WINIT_PATCHED "${WINIT_PATCHED}")
+    set(WINIT_FLUSH_NATIVE "\n    fn flush_pending_native_file_drops(&mut self) {\n        let pending = std::mem::take(&mut self.pending_native_file_drops);\n        let mut grouped: Vec<(winit::window::WindowId, LogicalPoint, String)> = Vec::new();\n        for (window_id, path, position) in pending {\n            if let Some((_, _, paths)) = grouped.iter_mut().find(|(id, _, _)| *id == window_id) {\n                if !paths.is_empty() { paths.push('\\n'); }\n                paths.push_str(&path.to_string_lossy());\n            } else {\n                grouped.push((window_id, position, path.to_string_lossy().into_owned()));\n            }\n        }\n        for (window_id, position, paths) in grouped {\n            let Some(window) = self.shared_backend_data.window_by_id(window_id) else { continue; };\n            let runtime_window = WindowInner::from_pub(window.window());\n            let mut data = DataTransfer::default();\n            data.set_plain_text(paths.into());\n            let mut event = DropEvent::default();\n            event.data = data;\n            event.position = corelib::api::LogicalPosition::new(position.x, position.y);\n            event.proposed_action = DragAction::Copy;\n            let allowed = AllowedDragActions { copy: true, move_: false, link: false };\n            runtime_window.process_mouse_input(MouseEvent::DragMove { event: event.clone(), allowed });\n            runtime_window.process_mouse_input(MouseEvent::Drop { event, allowed });\n        }\n    }\n")
     string(REPLACE
         "    }\n}\n\nimpl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {"
         "    }${WINIT_FLUSH_NATIVE}}\n\nimpl winit::application::ApplicationHandler<SlintEvent> for EventLoopState {"
         WINIT_PATCHED "${WINIT_PATCHED}")
     string(REPLACE
         "            WindowEvent::CursorMoved { position, .. } => {"
-        "            WindowEvent::DroppedFile(path) => {\n                self.pending_native_file_drops.push((window_id, path));\n            }\n            WindowEvent::CursorMoved { position, .. } => {"
+        "${WINIT_DROPPED_FILE_EVENT}            WindowEvent::CursorMoved { position, .. } => {"
         WINIT_PATCHED "${WINIT_PATCHED}")
     string(REPLACE
         "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_mouse_move();"
-        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_native_file_drops();\n        self.flush_pending_mouse_move();"
+        "    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {\n        self.flush_pending_mouse_move();\n        self.flush_pending_native_file_drops();"
         WINIT_PATCHED "${WINIT_PATCHED}")
+    endif()
+
+    if(NOT WINIT_PATCHED MATCHES "AWJ_NATIVE_FILE_DND_V3" OR
+       NOT WINIT_PATCHED MATCHES "native_file_drop_position" OR
+       NOT WINIT_PATCHED MATCHES "pending_native_file_drops.push\\(\\(window_id, path, position\\)\\)")
+        message(FATAL_ERROR "Could not upgrade Slint Winit native-drop event handling.")
+    endif()
     if(WINIT_PATCHED STREQUAL WINIT_CONTENT)
         message(FATAL_ERROR "Could not add Slint Winit native-drop event handling.")
     endif()


### PR DESCRIPTION
## Problem

On Windows, dragging files from Explorer into AWJ's input or output fields placed the drop event at the wrong UI position under DPI scaling. Windows Winit's OLE `DroppedFile` event can arrive without a preceding `CursorMoved`, so the buffered `self.cursor_pos` was stale.

## Fix

- Capture `GetCursorPos` at drop time and subtract `winit_window.inner_position()` to get client-area physical coordinates.
- Convert using `winit_window.scale_factor()` (not the Slint runtime's `runtime_window.scale_factor()`) so the Slint `DropArea` hit test matches the actual cursor position.
- Batch all paths from a single multi-file drop with the same position and dispatch them after flushing pending mouse moves in `about_to_wait`.
- Add `Win32_Foundation` feature to the Winit backend's Windows dependencies for `POINT` / `GetCursorPos`.
- Make the patch migration idempotent: replace the old expression only when present and skip silently when already migrated, avoiding a fatal error from broad `runtime_window.scale_factor` matches in unrelated event handlers.

## Testing

- `cmake --build build/x64/Release --config Release --target AWJ awj_ui_smoke_tests` — passed.
- `awj_ui_smoke_tests.exe` exit code 0.
- `git diff --check` passed.
- Manual drag-and-drop verified from Windows Explorer and Directory Opus into AWJ input/output fields under a 150% DPI display.
- Patch script rerun is idempotent (exit code 0 on second invocation).